### PR TITLE
[GIT_PULL] io_uring_prep_bind should take *const sockaddr

### DIFF
--- a/liburing-rs/src/lib.rs
+++ b/liburing-rs/src/lib.rs
@@ -567,7 +567,7 @@ pub unsafe fn io_uring_prep_connect(sqe: *mut io_uring_sqe, fd: c_int, addr: *co
 }
 
 #[inline]
-pub unsafe fn io_uring_prep_bind(sqe: *mut io_uring_sqe, fd: c_int, addr: *mut sockaddr,
+pub unsafe fn io_uring_prep_bind(sqe: *mut io_uring_sqe, fd: c_int, addr: *const sockaddr,
                                  addrlen: socklen_t)
 {
     io_uring_prep_rw(IORING_OP_BIND, sqe, fd, addr.cast(), 0, addrlen.into());


### PR DESCRIPTION
This PR changes the signature of `io_uring_prep_bind` to take `sockaddr` by `*const`.

The underlying call to `io_uring_prep_rw` already expects `*const`.

CC @cmazakas 

----
## git request-pull output:
```
The following changes since commit 73f4ee759a7b1ea5e582f37c68f85772154aec83:

  add missing query.h header (2025-09-21 08:56:14 -0700)

are available in the Git repository at:

  https://github.com/silvanshade/axboe-liburing bind-const-sockaddr

for you to fetch changes up to 2c22ad79530d1e278594696a456d01e121a11427:

  io_uring_prep_bind should take *const sockaddr (2025-09-23 11:43:37 -0600)

----------------------------------------------------------------
Darin Morrison (1):
      io_uring_prep_bind should take *const sockaddr

 liburing-rs/src/lib.rs | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```
